### PR TITLE
[WIP] add end-to-end demo w/ kind

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,1 +1,4 @@
+brew "go"
+brew "gettext" # for envsubst
+brew "jq"
 cask "docker"

--- a/e2e/consul.yaml
+++ b/e2e/consul.yaml
@@ -1,0 +1,32 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    run: consul
+  name: consul
+  namespace: default
+spec:
+  selector:
+    matchLabels:
+      run: consul
+  template:
+    metadata:
+      labels:
+        run: consul
+    spec:
+      hostNetwork: true
+      containers:
+      - image: consul
+        imagePullPolicy: Always
+        name: consul
+        args: 
+        - agent
+        - -join=$CONSUL_IP
+        - -bind={{ GetInterfaceIP "eth0" }}
+        - -client={{ GetInterfaceIP "eth0" }}
+        - -advertise={{ GetInterfaceIP "eth0" }}
+        - -rejoin
+        - -retry-join={{ GetInterfaceIP "eth0" }}
+        ports:
+        - containerPort: 8500
+          protocol: TCP

--- a/e2e/docker-compose.yaml
+++ b/e2e/docker-compose.yaml
@@ -1,0 +1,42 @@
+version: '3'
+services:
+  consul-template:
+    image: hashicorp/consul-template:alpine
+    # change the entrypoint so consul-template can run as root.  Otherwise, it
+    # can't write to the shared /etc/nginx/conf.d since that's root owned in
+    # the edge-nginx container.
+    entrypoint:
+    - consul-template
+    - -template
+    - '/etc/consul-template/default.conf.ctmpl:/etc/nginx/conf.d/default.conf:pkill -HUP "nginx: master"'
+    - -consul-addr=http://consul-server:8500
+    pid: service:edge-nginx
+    network_mode: bridge
+    links:
+    - consul-server
+    volumes:
+    - nginx-conf-d:/etc/nginx/conf.d:nocopy
+    - ./edge-nginx/default.conf.ctmpl:/etc/consul-template/default.conf.ctmpl
+  edge-nginx:
+    image: nginx:1.15-alpine
+    ports:
+    - "80"
+    network_mode: bridge
+    volumes:
+    - nginx-conf-d:/etc/nginx/conf.d:nocopy
+  consul-server:
+    image: consul
+    ports:
+    - "8500"
+    network_mode: bridge
+    command:
+    - agent
+    - -server
+    - -bootstrap
+    - -bind=0.0.0.0
+    - -client=0.0.0.0
+    - -advertise={{ GetInterfaceIP "eth0" }}
+    - -data-dir=/consul/data
+    - -config-dir=/consul/config
+volumes:
+  nginx-conf-d:

--- a/e2e/edge-nginx/default.conf.ctmpl
+++ b/e2e/edge-nginx/default.conf.ctmpl
@@ -1,0 +1,30 @@
+{{ range services }}
+  {{- if .Tags | contains "kube-service-exporter" }}
+upstream {{ .Name }} {
+  zone upstream-{{ .Name }} 64k;
+  {{ range service .Name }}server {{ .Address }}:{{ .Port }} max_fails=3 fail_timeout=60 weight=1;
+  {{ else }}server 127.0.0.1:65535; # force a 502{{ end }}
+}
+  {{- end }}
+{{- end }}
+
+server {
+  listen 80 default_server;
+
+  location / {
+    root /usr/share/nginx/html/;
+    index index.html;
+  }
+
+  location /stub_status {
+    stub_status;
+  }
+
+{{ range services }}
+  {{- if .Tags | contains "kube-service-exporter" }}
+  location /{{ .Name }}/ {
+    proxy_pass http://{{ .Name }}/;
+  }
+  {{- end }}
+{{- end }}
+}

--- a/e2e/kube-service-exporter.yaml
+++ b/e2e/kube-service-exporter.yaml
@@ -40,7 +40,9 @@ spec:
               command: ["sleep", "5"]
         env:
         - name: KSE_CONSUL_HOST
-          value: consul # this references the consul Service in your cluster
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
         - name: KSE_POD_NAME
           valueFrom:
             fieldRef:
@@ -48,4 +50,4 @@ spec:
         - name: KSE_SERVICES_ENABLED
           value: "true"
         - name: KSE_CLUSTER_ID
-          value: "minikube"
+          value: $CLUSTER_ID

--- a/e2e/nginx.yaml
+++ b/e2e/nginx.yaml
@@ -1,0 +1,96 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx
+  annotations:
+    kube-service-exporter.github.com/exported: "true"
+    kube-service-exporter.github.com/load-balancer-service-per-cluster: "false"
+spec:
+  ports:
+  - port: 80
+    targetPort: http
+    protocol: TCP
+    name: http
+  selector:
+    run: nginx
+  type: LoadBalancer
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx
+data:
+  nginx.conf: |
+    env KUBE_HOSTNAME;
+
+    worker_processes  1;
+
+    events {
+        worker_connections  1024;
+    }
+
+
+    http {
+        include       mime.types;
+        default_type  application/octet-stream;
+
+        sendfile        on;
+        keepalive_timeout  65;
+
+        server {
+            listen       80;
+            server_name  localhost;
+            set_by_lua   $kube_hostname 'return os.getenv("KUBE_HOSTNAME")';
+            add_header   X-Pod-Name $hostname;
+            add_header   X-Hostname $kube_hostname;
+
+            location / {
+                root   /usr/local/openresty/nginx/html;
+                index  index.html index.htm;
+            }
+
+            error_page   500 502 503 504  /50x.html;
+            location = /50x.html {
+                root   /usr/local/openresty/nginx/html;
+            }
+        }
+    }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx
+spec:
+  selector:
+    matchLabels:
+      run: nginx
+  template:
+    metadata:
+      labels:
+        run: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: openresty/openresty
+#        command: ['sleep', '3600'] 
+        ports:
+        - name: http
+          containerPort: 80
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 80
+            scheme: HTTP
+        env:
+        - name: KUBE_HOSTNAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        volumeMounts:
+        - name: nginx
+          mountPath: /usr/local/openresty/nginx/conf/nginx.conf
+          subPath: nginx.conf
+      volumes:
+      - name: nginx
+        configMap:
+          name: nginx

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -2,4 +2,8 @@
 
 if [ "$(uname)" = "Darwin" ]; then
   brew bundle
+  [ -x $(which envsubst) ] || brew link --force gettext
 fi
+
+# install kind (Kubernetes IN Docker)
+[ -x $(which kind) ] || go get -u sigs.k8s.io/kind

--- a/script/e2e
+++ b/script/e2e
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+
+# set -x
+
+REPOROOT="$( cd "$(dirname "$0")/.." ; pwd -P )"
+CLUSTERS=$(kind get clusters)
+
+prepare() {
+  mkdir -p "$REPOROOT/tmp"
+}
+
+create_clusters() {
+  kind create cluster --name cluster1
+  kind create cluster --name cluster2
+}
+
+docker_compose() {
+  docker-compose -f "$REPOROOT/e2e/docker-compose.yaml" "$@"
+}
+
+consul_ip() {
+  local consul_container_id 
+  consul_container_id=$(docker_compose ps -q consul-server)
+  docker inspect "$consul_container_id" | jq -r .[].NetworkSettings.IPAddress
+}
+
+cleanup() {
+  docker_compose kill
+  for config in tmp/kube-service-exporter.yaml tmp/consul.yaml examples/rbac.yaml; do
+    kubectlall delete -f "$REPOROOT/$config"
+  done
+  kind delete cluster --name cluster1
+  kind delete cluster --name cluster2
+  rm -rf "REPOROOT/tmp"
+}
+
+_kubectl() {
+  local config
+  config=$1
+  shift
+  KUBECONFIG="$(kind get kubeconfig-path --name=$config)" kubectl "$@"
+}
+
+kubectlall() {
+  _kubectl cluster1 "$@"
+  _kubectl cluster2 "$@"
+}
+
+apply_kse() {
+  kubectlall apply -f "$REPOROOT/examples/rbac.yaml"
+
+  for cluster in cluster1 cluster2; do
+    CLUSTER_ID="$cluster" envsubst < "$REPOROOT/e2e/kube-service-exporter.yaml" > "$REPOROOT/tmp/kube-service-exporter.yaml"
+    _kubectl "$cluster" apply -f "$REPOROOT/tmp/kube-service-exporter.yaml"
+  done
+}
+
+main() {
+  prepare
+  cleanup || true
+  create_clusters
+
+  docker_compose up -d
+  CONSUL_IP=$(consul_ip) envsubst < "$REPOROOT/e2e/consul.yaml" > "$REPOROOT/tmp/consul.yaml"
+
+  kubectlall apply -f "$REPOROOT/tmp/consul.yaml"
+  # wait for consul to come up and join
+  # TODO: actually check consul membership instead of sleeping
+  sleep 30
+  apply_kse
+  kubectlall delete -f "$REPOROOT/e2e/nginx.yaml"
+  kubectlall apply -f "$REPOROOT/e2e/nginx.yaml"
+}
+
+main


### PR DESCRIPTION
This adds an end-to-end demo of kube-service-exporter using [Kind](https://github.com/kubernetes-sigs/kind) of an edge load balancer load balancing between 2 clusters.

@guineveresaenger and I spent a bunch of time on zoom this week fighting with minikube to try to come up with an end-to-end demo, but kept getting thwarted by virtualbox networking.  @guineveresaenger had mentioned [Kind](https://github.com/kubernetes-sigs/kind) and since I was working on writing a blog post which could be supported by a simple example, I decided to give it a whirl.  Since Kind leverages the default docker bridge network, the networking problems just went away!

It runs 2 k8s clusters with kube-service-exporter, an nginx backend, and consul agents.  Outside the cluster (with docker-compose), it runs a consul server, an edge nginx server (which load balances to the backend nginxs inside the cluster) with a config managed by consul-template.
 
```
[22:09:44] aaronbbrown@caprica:~/go/src/github.com/github/kube-service-exporter (abb-e2e *=)$ script/e2e
Killing e2e_consul-template_1 ... done
Killing e2e_edge-nginx_1      ... done
Killing e2e_consul-server_1   ... done
daemonset.apps "kube-service-exporter" deleted
daemonset.apps "kube-service-exporter" deleted
daemonset.apps "consul" deleted
daemonset.apps "consul" deleted
serviceaccount "kube-service-exporter" deleted
clusterrole.rbac.authorization.k8s.io "kube-service-exporter" deleted
clusterrolebinding.rbac.authorization.k8s.io "kube-service-exporter" deleted
serviceaccount "kube-service-exporter" deleted
clusterrole.rbac.authorization.k8s.io "kube-service-exporter" deleted
clusterrolebinding.rbac.authorization.k8s.io "kube-service-exporter" deleted
Deleting cluster "cluster1" ...
Deleting cluster "cluster2" ...
Creating cluster "cluster1" ...
 ✓ Ensuring node image (kindest/node:v1.13.3) 🖼
 ✓ [control-plane] Creating node container 📦
 ✓ [control-plane] Fixing mounts 🗻
 ✓ [control-plane] Configuring proxy 🐋
 ✓ [control-plane] Starting systemd 🖥
 ✓ [control-plane] Waiting for docker to be ready 🐋
 ✓ [control-plane] Pre-loading images 🐋
 ✓ [control-plane] Creating the kubeadm config file ⛵
 ✓ [control-plane] Starting Kubernetes (this may take a minute) ☸
Cluster creation complete. You can now use the cluster with:

export KUBECONFIG="$(kind get kubeconfig-path --name="cluster1")"
kubectl cluster-info
Creating cluster "cluster2" ...
 ✓ Ensuring node image (kindest/node:v1.13.3) 🖼
 ✓ [control-plane] Creating node container 📦
 ✓ [control-plane] Fixing mounts 🗻
 ✓ [control-plane] Configuring proxy 🐋
 ✓ [control-plane] Starting systemd 🖥
 ✓ [control-plane] Waiting for docker to be ready 🐋
 ✓ [control-plane] Pre-loading images 🐋
 ✓ [control-plane] Creating the kubeadm config file ⛵
 ✓ [control-plane] Starting Kubernetes (this may take a minute) ☸
Cluster creation complete. You can now use the cluster with:

export KUBECONFIG="$(kind get kubeconfig-path --name="cluster2")"
kubectl cluster-info
Starting e2e_consul-server_1 ... done
Starting e2e_edge-nginx_1    ... done
Starting e2e_consul-template_1 ... done
daemonset.apps "consul" created
daemonset.apps "consul" created
serviceaccount "kube-service-exporter" created
clusterrole.rbac.authorization.k8s.io "kube-service-exporter" created
clusterrolebinding.rbac.authorization.k8s.io "kube-service-exporter" created
serviceaccount "kube-service-exporter" created
clusterrole.rbac.authorization.k8s.io "kube-service-exporter" created
clusterrolebinding.rbac.authorization.k8s.io "kube-service-exporter" created
daemonset.apps "kube-service-exporter" created
daemonset.apps "kube-service-exporter" created
Error from server (NotFound): error when deleting "/Users/aaronbbrown/go/src/github.com/github/kube-service-exporter/e2e/nginx.yaml": services "nginx" not found
Error from server (NotFound): error when deleting "/Users/aaronbbrown/go/src/github.com/github/kube-service-exporter/e2e/nginx.yaml": configmaps "nginx" not found
Error from server (NotFound): error when stopping "/Users/aaronbbrown/go/src/github.com/github/kube-service-exporter/e2e/nginx.yaml": deployments.extensions "nginx" not found
Error from server (NotFound): error when deleting "/Users/aaronbbrown/go/src/github.com/github/kube-service-exporter/e2e/nginx.yaml": services "nginx" not found
Error from server (NotFound): error when deleting "/Users/aaronbbrown/go/src/github.com/github/kube-service-exporter/e2e/nginx.yaml": configmaps "nginx" not found
Error from server (NotFound): error when stopping "/Users/aaronbbrown/go/src/github.com/github/kube-service-exporter/e2e/nginx.yaml": deployments.extensions "nginx" not found
service "nginx" created
configmap "nginx" created
deployment.apps "nginx" created
service "nginx" created
configmap "nginx" created
deployment.apps "nginx" created
```

After a minute or so, everything converges and you can hit the edge nginx and see it load balancing across the different clusters:

```
[22:14:09] aaronbbrown@caprica:~/go/src/github.com/github/kube-service-exporter/e2e (abb-e2e *=)$ for x in {1..10}; do curl -s -I http://$(docker-compose port edge-nginx 80)/default-nginx-http/ | grep X-Hostname; done
X-Hostname: cluster2-control-plane
X-Hostname: cluster1-control-plane
X-Hostname: cluster2-control-plane
X-Hostname: cluster1-control-plane
X-Hostname: cluster2-control-plane
X-Hostname: cluster1-control-plane
X-Hostname: cluster2-control-plane
X-Hostname: cluster1-control-plane
X-Hostname: cluster2-control-plane
X-Hostname: cluster1-control-plane
```