### PR TITLE
Allows selection of datacenter with CONSUL_DATACENTER

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ The following Annotations are supported on the Kubernetes Service resource. Note
 
 Exported services are configured with Annotations on the Service, but `kube-service-exporter` itself is configured with environment variables.  The following configuration options are available:
 * `KSE_CONSUL_KV_PREFIX` (default: kube-service-exporter) - The prefix to use when setting Consul KV keys.
+* `KSE_CONSUL_DATACENTER` (default: Consul Agent Default) - The name of the Consul Datacenter to use
 * `KSE_CONSUL_HOST` (default: 127.0.0.1) - The IP or hostname for the Consul Agent.
 * `KSE_CONSUL_PORT` (default: 8500) - The HTTP port for the Consul Agent.
 * `KSE_DOGSTATSD_ENABLED` (default: true) - Set to "false" to disable sending of dogstatsd metrics

--- a/main.go
+++ b/main.go
@@ -47,6 +47,7 @@ func main() {
 	namespaces := viper.GetStringSlice("NAMESPACE_LIST")
 	clusterId := viper.GetString("CLUSTER_ID")
 	kvPrefix := viper.GetString("CONSUL_KV_PREFIX")
+	consulDatacenter := viper.GetString("CONSUL_DATACENTER")
 	consulHost := viper.GetString("CONSUL_HOST")
 	consulPort := viper.GetInt("CONSUL_PORT")
 	podName := viper.GetString("POD_NAME")
@@ -99,6 +100,11 @@ func main() {
 	consulCfg := capi.DefaultConfig()
 	consulCfg.Address = fmt.Sprintf("%s:%d", consulIPs[0].String(), consulPort)
 	log.Printf("Using Consul agent at %s", consulCfg.Address)
+
+	if viper.IsSet("CONSUL_DATACENTER") {
+		consulCfg.Datacenter = consulDatacenter
+		log.Printf("Using Consul datacenter %s", consulCfg.Datacenter)
+	}
 
 	elector, err := leader.NewConsulLeaderElector(consulCfg, kvPrefix, clusterId, podName)
 	if err != nil {


### PR DESCRIPTION
Sets consul configuration to use specified datacenter to support #42 