### PR TITLE
Allow configurable service key prefix via go template

### DIFF
--- a/main.go
+++ b/main.go
@@ -59,6 +59,7 @@ func main() {
 	httpIp := viper.GetString("HTTP_IP")
 	httpPort := viper.GetInt("HTTP_PORT")
 	servicesEnabled := viper.GetBool("SERVICES_ENABLED")
+	servicesKeyTemplate := viper.GetString("SERVICES_KEY_TEMPLATE")
 
 	stopTimeout := 10 * time.Second
 	stoppedC := make(chan struct{})
@@ -118,6 +119,7 @@ func main() {
 	targetCfg := controller.ConsulTargetConfig{
 		ConsulConfig:    consulTargetCfg,
 		KvPrefix:        kvPrefix,
+		ServiceKeyTmpl:  servicesKeyTemplate,
 		ClusterId:       clusterId,
 		Elector:         elector,
 		ServicesEnabled: servicesEnabled,

--- a/main.go
+++ b/main.go
@@ -119,7 +119,7 @@ func main() {
 	targetCfg := controller.ConsulTargetConfig{
 		ConsulConfig:    consulTargetCfg,
 		KvPrefix:        kvPrefix,
-		ServiceKeyTmpl:  servicesKeyTemplate,
+		ServicesKeyTmpl: servicesKeyTemplate,
 		ClusterId:       clusterId,
 		Elector:         elector,
 		ServicesEnabled: servicesEnabled,

--- a/pkg/controller/consul_target.go
+++ b/pkg/controller/consul_target.go
@@ -8,7 +8,9 @@ import (
 	"net"
 	"reflect"
 	"sort"
+	"strings"
 	"sync"
+	"text/template"
 	"time"
 
 	"github.com/pkg/errors"
@@ -29,6 +31,7 @@ type ConsulTarget struct {
 	servicesEnabled bool
 	kv              *consul.InstrumentedKV
 	agent           *consul.InstrumentedAgent
+	serviceKeyTmpl  string
 }
 
 type ExportedNode struct {
@@ -39,8 +42,14 @@ type ExportedNode struct {
 type ConsulTargetConfig struct {
 	ConsulConfig *capi.Config
 	KvPrefix     string
-	ClusterId    string
-	Elector      leader.LeaderElector
+
+	// ServiceKeyTmpl is the go template used for each service. Defaults to
+	// services/{{ .Id() }}
+	// Can be used to namespace keys for better lookup efficiency, e.g.
+	// services/{{ .LoadBalancerClass }}/{{ .Id() }}
+	ServiceKeyTmpl string
+	ClusterId      string
+	Elector        leader.LeaderElector
 	// ServicesEnabled defines whether or not to store services as Consul Services
 	// in addition to in KV metadata. This option requires kube-service-exporter
 	// to be deployed as a DaemonSet
@@ -71,6 +80,7 @@ func NewConsulTarget(cfg ConsulTargetConfig) (*ConsulTarget, error) {
 		servicesEnabled: cfg.ServicesEnabled,
 		kv:              consul.NewInstrumentedKV(client),
 		agent:           consul.NewInstrumentedAgent(client),
+		serviceKeyTmpl:  cfg.ServiceKeyTmpl,
 	}, nil
 }
 
@@ -124,8 +134,12 @@ func (t *ConsulTarget) Delete(es *ExportedService) (bool, error) {
 
 	if t.elector.IsLeader() {
 		log.Printf("[LEADER] Deleting KV metadata for %s", es.Id())
-		_, err := t.kv.DeleteTree(t.metadataPrefix(es), &capi.WriteOptions{}, []string{"kv:metadata"})
+		prefix, err := t.metadataPrefix(es)
 		if err != nil {
+			return false, err
+		}
+
+		if _, err := t.kv.DeleteTree(prefix, &capi.WriteOptions{}, []string{"kv:metadata"}); err != nil {
 			return false, err
 		}
 	}
@@ -133,8 +147,23 @@ func (t *ConsulTarget) Delete(es *ExportedService) (bool, error) {
 	return true, nil
 }
 
-func (t *ConsulTarget) metadataPrefix(es *ExportedService) string {
-	return fmt.Sprintf("%s/services/%s/clusters/%s", t.kvPrefix, es.Id(), es.ClusterId)
+func (t *ConsulTarget) metadataPrefix(es *ExportedService) (string, error) {
+	if t.serviceKeyTmpl != "" {
+		funcMap := template.FuncMap{"id": es.Id}
+
+		tmpl, err := template.New("metadata-prefix").Funcs(funcMap).Parse(t.serviceKeyTmpl)
+		if err != nil {
+			return "", err
+		}
+
+		var builder strings.Builder
+		if err := tmpl.Execute(&builder, es); err != nil {
+			return "", err
+		}
+
+		return fmt.Sprintf("%s/%s/clusters/%s", t.kvPrefix, builder.String(), es.ClusterId), nil
+	}
+	return fmt.Sprintf("%s/services/%s/clusters/%s", t.kvPrefix, es.Id(), es.ClusterId), nil
 }
 
 // Write out metadata to where it belongs in Consul using a transaction.  This
@@ -145,8 +174,13 @@ func (t *ConsulTarget) writeKV(es *ExportedService) error {
 		return errors.Wrap(err, "Error marshaling ExportedService JSON")
 	}
 
+	key, err := t.metadataPrefix(es)
+	if err != nil {
+		return errors.Wrap(err, "error calculating key prefix")
+	}
+
 	kvPair := capi.KVPair{
-		Key:   t.metadataPrefix(es),
+		Key:   key,
 		Value: esJson,
 	}
 
@@ -173,7 +207,11 @@ func (t *ConsulTarget) asrFromExportedService(es *ExportedService) *capi.AgentSe
 // shouldUpdateKV checks if the hash of the ExportedService is the same as the
 // hash stored in Consul.  If they differ, KV data is updated.
 func (t *ConsulTarget) shouldUpdateKV(es *ExportedService) (bool, error) {
-	key := t.metadataPrefix(es)
+	key, err := t.metadataPrefix(es)
+	if err != nil {
+		return false, errors.Wrap(err, "error calculating key prefix")
+	}
+
 	qo := capi.QueryOptions{RequireConsistent: true}
 
 	kvPair, _, err := t.kv.Get(key, &qo, []string{"kv:metadata"})

--- a/pkg/controller/consul_target_test.go
+++ b/pkg/controller/consul_target_test.go
@@ -63,12 +63,16 @@ func TestConsulTargetSuite(t *testing.T) {
 }
 
 func (s *ConsulTargetSuite) SetupTest() {
-	s.consulServer = tests.NewTestingConsulServer(s.T())
-	s.consulServer.Start()
+	s.consulServer = tests.NewTestingConsulServer()
+	if err := s.consulServer.Start(); err != nil {
+		s.FailNow("error starting consul", err)
+	}
 }
 
 func (s *ConsulTargetSuite) TearDownTest() {
-	s.consulServer.Stop()
+	if err := s.consulServer.Stop(); err != nil {
+		s.FailNow("error stopping consul", err)
+	}
 }
 
 func (s *ConsulTargetSuite) TestCreate() {

--- a/pkg/controller/consul_target_test.go
+++ b/pkg/controller/consul_target_test.go
@@ -251,9 +251,9 @@ func (s *ConsulTargetSuite) TestShouldUpdateService() {
 	target, _ := NewConsulTarget(newDefaultConsulTargetConfig(s.consulServer))
 	es := &ExportedService{
 		ClusterId: ClusterId,
-		Namespace: "ns1",
-		Name:      "name1",
-		PortName:  "http",
+		Namespace: "unique-ns1",
+		Name:      "unique-name1",
+		PortName:  "unique-http",
 		Port:      32001}
 
 	asr := target.asrFromExportedService(es)

--- a/pkg/controller/consul_target_test.go
+++ b/pkg/controller/consul_target_test.go
@@ -19,6 +19,16 @@ const (
 	ClusterId = "cluster1"
 )
 
+func newDefaultConsulTargetConfig(server *tests.TestingConsulServer) ConsulTargetConfig {
+	elector := &fakeElector{isLeader: true, hasLeader: true}
+	return ConsulTargetConfig{
+		ConsulConfig:    server.Config,
+		KvPrefix:        KvPrefix,
+		ClusterId:       ClusterId,
+		ServicesEnabled: true,
+		Elector:         elector}
+}
+
 // A fake leader elector
 type fakeElector struct {
 	isLeader  bool
@@ -46,7 +56,6 @@ var _ leader.LeaderElector = (*fakeElector)(nil)
 type ConsulTargetSuite struct {
 	suite.Suite
 	consulServer *tests.TestingConsulServer
-	target       *ConsulTarget
 }
 
 func TestConsulTargetSuite(t *testing.T) {
@@ -56,13 +65,6 @@ func TestConsulTargetSuite(t *testing.T) {
 func (s *ConsulTargetSuite) SetupTest() {
 	s.consulServer = tests.NewTestingConsulServer(s.T())
 	s.consulServer.Start()
-	elector := &fakeElector{isLeader: true, hasLeader: true}
-	s.target, _ = NewConsulTarget(ConsulTargetConfig{
-		ConsulConfig:    s.consulServer.Config,
-		KvPrefix:        KvPrefix,
-		ClusterId:       ClusterId,
-		ServicesEnabled: true,
-		Elector:         elector})
 }
 
 func (s *ConsulTargetSuite) TearDownTest() {
@@ -70,6 +72,7 @@ func (s *ConsulTargetSuite) TearDownTest() {
 }
 
 func (s *ConsulTargetSuite) TestCreate() {
+	target, _ := NewConsulTarget(newDefaultConsulTargetConfig(s.consulServer))
 	s.T().Run("creates cluster-independent service", func(t *testing.T) {
 		es := &ExportedService{
 			ClusterId: ClusterId,
@@ -78,7 +81,7 @@ func (s *ConsulTargetSuite) TestCreate() {
 			PortName:  "http",
 			Port:      32001}
 
-		ok, err := s.target.Create(es)
+		ok, err := target.Create(es)
 		s.NoError(err)
 		s.True(ok)
 
@@ -102,7 +105,7 @@ func (s *ConsulTargetSuite) TestCreate() {
 			ServicePerCluster: true,
 		}
 
-		ok, err := s.target.Create(es)
+		ok, err := target.Create(es)
 		s.NoError(err)
 		s.True(ok)
 
@@ -132,7 +135,7 @@ func (s *ConsulTargetSuite) TestCreate() {
 		}
 
 		kv := s.consulServer.Client.KV()
-		ok, err := s.target.Create(es)
+		ok, err := target.Create(es)
 		s.NoError(err)
 		s.True(ok)
 
@@ -147,9 +150,42 @@ func (s *ConsulTargetSuite) TestCreate() {
 		s.NoError(err)
 		s.Equal(meta["load_balancer_class"], "internal")
 	})
+
+	s.T().Run("Writes to ServiceKeyTmpl", func(t *testing.T) {
+		target, _ := NewConsulTarget(newDefaultConsulTargetConfig(s.consulServer))
+		target.serviceKeyTmpl = "services/{{ .LoadBalancerClass }}/{{ id }}"
+
+		es := &ExportedService{
+			ClusterId:         ClusterId,
+			Namespace:         "ns3",
+			Name:              "name3",
+			PortName:          "http",
+			Port:              32003,
+			ServicePerCluster: false,
+			LoadBalancerClass: "internal",
+			HealthCheckPort:   32303,
+		}
+
+		kv := s.consulServer.Client.KV()
+		ok, err := target.Create(es)
+		s.NoError(err)
+		s.True(ok)
+
+		key := fmt.Sprintf("%s/services/%s/%s-%s-%s/clusters/%s", KvPrefix, es.LoadBalancerClass, es.Namespace, es.Name, es.PortName, es.ClusterId)
+		pair, _, err := kv.Get(key, &capi.QueryOptions{})
+		require.NoErrorf(s.T(), err, "Expected err for %s to be nil, got %+v", key, err)
+		require.NotNilf(s.T(), pair, "expected KVPair for %s to be not nil", key)
+
+		var meta map[string]interface{}
+
+		err = json.Unmarshal(pair.Value, &meta)
+		s.NoError(err)
+		s.Equal(meta["load_balancer_class"], "internal")
+	})
 }
 
 func (s *ConsulTargetSuite) TestDelete() {
+	target, _ := NewConsulTarget(newDefaultConsulTargetConfig(s.consulServer))
 	es := &ExportedService{
 		ClusterId: ClusterId,
 		Namespace: "ns1",
@@ -159,7 +195,7 @@ func (s *ConsulTargetSuite) TestDelete() {
 	kv := s.consulServer.Client.KV()
 	prefix := fmt.Sprintf("%s/services/ns1-name1-http/clusters/%s", KvPrefix, ClusterId)
 
-	ok, err := s.target.Create(es)
+	ok, err := target.Create(es)
 	s.NoError(err)
 	s.True(ok)
 
@@ -171,7 +207,7 @@ func (s *ConsulTargetSuite) TestDelete() {
 	s.NoError(err)
 	s.NotEmpty(keys)
 
-	ok, err = s.target.Delete(es)
+	ok, err = target.Delete(es)
 	s.NoError(err)
 	s.True(ok)
 
@@ -185,6 +221,7 @@ func (s *ConsulTargetSuite) TestDelete() {
 }
 
 func (s *ConsulTargetSuite) TestShouldUpdateKV() {
+	target, _ := NewConsulTarget(newDefaultConsulTargetConfig(s.consulServer))
 	es := &ExportedService{
 		ClusterId: ClusterId,
 		Namespace: "ns1",
@@ -192,25 +229,26 @@ func (s *ConsulTargetSuite) TestShouldUpdateKV() {
 		PortName:  "http",
 		Port:      32001}
 
-	ok, err := s.target.shouldUpdateKV(es)
+	ok, err := target.shouldUpdateKV(es)
 	s.NoError(err)
 	s.True(ok, "Should update KV before first create")
 
-	ok, err = s.target.Create(es)
+	ok, err = target.Create(es)
 	s.NoError(err)
 	s.True(ok)
 
-	ok, err = s.target.shouldUpdateKV(es)
+	ok, err = target.shouldUpdateKV(es)
 	s.NoError(err)
 	s.False(ok, "Should not update KV if same")
 
 	es.Port += 1
-	ok, err = s.target.shouldUpdateKV(es)
+	ok, err = target.shouldUpdateKV(es)
 	s.NoError(err)
 	s.True(ok, "Should update KV after change")
 }
 
 func (s *ConsulTargetSuite) TestShouldUpdateService() {
+	target, _ := NewConsulTarget(newDefaultConsulTargetConfig(s.consulServer))
 	es := &ExportedService{
 		ClusterId: ClusterId,
 		Namespace: "ns1",
@@ -218,30 +256,31 @@ func (s *ConsulTargetSuite) TestShouldUpdateService() {
 		PortName:  "http",
 		Port:      32001}
 
-	asr := s.target.asrFromExportedService(es)
-	ok, err := s.target.shouldUpdateService(asr)
+	asr := target.asrFromExportedService(es)
+	ok, err := target.shouldUpdateService(asr)
 	s.NoError(err)
 	s.True(ok, "Should update service before first create")
 
-	ok, err = s.target.Create(es)
+	ok, err = target.Create(es)
 	s.NoError(err)
 	s.True(ok)
 
-	ok, err = s.target.shouldUpdateService(asr)
+	ok, err = target.shouldUpdateService(asr)
 	s.NoError(err)
 	s.False(ok, "Should not update service if AgentServiceRegistration same")
 
 	es.Port += 1
-	asr = s.target.asrFromExportedService(es)
-	ok, err = s.target.shouldUpdateService(asr)
+	asr = target.asrFromExportedService(es)
+	ok, err = target.shouldUpdateService(asr)
 	s.NoError(err)
 	s.True(ok, "Should update Service after change")
 }
 
 func (s *ConsulTargetSuite) TestShouldWriteNodes() {
+	target, _ := NewConsulTarget(newDefaultConsulTargetConfig(s.consulServer))
 	var exportedNodes []ExportedNode
 	node := testingNode()
-	s.target.WriteNodes([]*v1.Node{&node})
+	target.WriteNodes([]*v1.Node{&node})
 
 	key := fmt.Sprintf("%s/nodes/%s", KvPrefix, ClusterId)
 	pair, meta, err := s.consulServer.Client.KV().Get(key, nil)
@@ -251,7 +290,7 @@ func (s *ConsulTargetSuite) TestShouldWriteNodes() {
 	s.Len(exportedNodes, 1, "should write 1 node")
 	lastIndex := meta.LastIndex
 
-	s.target.WriteNodes([]*v1.Node{&node})
+	target.WriteNodes([]*v1.Node{&node})
 	_, meta, _ = s.consulServer.Client.KV().Get(key, nil)
 	s.Equal(lastIndex, meta.LastIndex, "Should not write duplicate data")
 }

--- a/pkg/controller/consul_target_test.go
+++ b/pkg/controller/consul_target_test.go
@@ -155,9 +155,9 @@ func (s *ConsulTargetSuite) TestCreate() {
 		s.Equal(meta["load_balancer_class"], "internal")
 	})
 
-	s.T().Run("Writes to ServiceKeyTmpl", func(t *testing.T) {
+	s.T().Run("Writes to ServicesKeyTmpl", func(t *testing.T) {
 		target, _ := NewConsulTarget(newDefaultConsulTargetConfig(s.consulServer))
-		target.serviceKeyTmpl = "services/{{ .LoadBalancerClass }}/{{ id }}"
+		target.servicesKeyTmpl = "{{ .LoadBalancerClass }}/{{ id }}"
 
 		es := &ExportedService{
 			ClusterId:         ClusterId,

--- a/pkg/leader/consul_leader_elector_test.go
+++ b/pkg/leader/consul_leader_elector_test.go
@@ -37,8 +37,10 @@ func TestConsulLeaderElectorSuite(t *testing.T) {
 }
 
 func (s *ConsulLeaderElectorSuite) SetupTest() {
-	s.consulServer = tests.NewTestingConsulServer(s.T())
-	s.consulServer.Start()
+	s.consulServer = tests.NewTestingConsulServer()
+	if err := s.consulServer.Start(); err != nil {
+		s.FailNow("error starting consul", err)
+	}
 	elector, err := NewConsulLeaderElector(s.consulServer.Config, KvPrefix, ClusterId, ClientId)
 	require.NoError(s.T(), err)
 	s.elector = elector
@@ -47,7 +49,9 @@ func (s *ConsulLeaderElectorSuite) SetupTest() {
 
 func (s *ConsulLeaderElectorSuite) TearDownTest() {
 	s.elector.Stop()
-	s.consulServer.Stop()
+	if err := s.consulServer.Stop(); err != nil {
+		s.FailNow("error stopping consul", err)
+	}
 }
 
 func (s *ConsulLeaderElectorSuite) TestElection() {
@@ -73,8 +77,10 @@ func (s *ConsulLeaderElectorSuite) TestElection() {
 }
 
 func TestNewElection(t *testing.T) {
-	consulServer := tests.NewTestingConsulServer(t)
-	consulServer.Start()
+	consulServer := tests.NewTestingConsulServer()
+	if err := consulServer.Start(); err != nil {
+		t.Fatal("error starting consul", err)
+	}
 	elector1, err := NewConsulLeaderElector(consulServer.Config, KvPrefix, ClusterId, ClientId)
 	require.NoError(t, err)
 	go elector1.Run()
@@ -89,5 +95,7 @@ func TestNewElection(t *testing.T) {
 	assert.True(t, WaitForIsLeader(elector2))
 	assert.True(t, elector2.IsLeader())
 	elector2.Stop()
-	consulServer.Stop()
+	if err := consulServer.Stop(); err != nil {
+		t.Fatal("error stopping consul", err)
+	}
 }


### PR DESCRIPTION
Currently all keys are under the Consul prefix:
```
$PREFIX/services/$SERVICE_ID/clusters/$CLUSTER_ID
```

This makes the middle portion of that configurable via a go template and the environment variable `KSE_SERVICE_KEY_TEMPLATE` for better addressability in large templates.  An example use case would be for referncing the load balancer class inside the template:

```
KSE_SERVICE_KEY_TEMPLATE="{{ .LoadBalancerClass }}/{{ id }}"
```
This would yield a key like:
```
$PREFIX/services/$LOAD_BALANCER_CLASS/$SERVICE_ID/clusters/$CLUSTER_ID
```

The `id` method is supplied as a way to reference the canonical service ID in the path.


The default remains as it is now, which is _equivalent_ to
```
KSE_SERVICE_KEY_TEMPLATE="{{ id }}"
```

With great power comes great responsibility and it's important that none fo the template variables referenced be nil or empty strings or data under the prefix will appear corrupted.  In the example above, if `.LoadBalancerClass` is not in the service metadata (via the `kube-service-exporter.github.com/load-balancer-class` annotation), the result will be a key like:

```
$PREFIX/services//$SERVICE_ID/clusters/$CLUSTER_ID
```

Also, it's important that `{{ id }}` be present somewhere or else there will be no way to reference each service separately.  As of now there is no error checking around these conditions.

Documentation will follow.