### PR TITLE
use container port when port is unnamed

### DIFF
--- a/pkg/controller/exportable_service.go
+++ b/pkg/controller/exportable_service.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/mitchellh/hashstructure"
 	"github.com/pkg/errors"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 )
 
 const (
@@ -134,7 +134,9 @@ func NewExportedService(service *v1.Service, clusterId string, portIdx int) (*Ex
 	}
 
 	if es.PortName == "" {
-		es.PortName = strconv.Itoa(int(es.Port))
+		// use the container port since it will be consistent across clusters
+		// and the NodePort will not.
+		es.PortName = strconv.Itoa(int(service.Spec.Ports[portIdx].Port))
 	}
 
 	if service.Annotations == nil {
@@ -234,7 +236,7 @@ func (es *ExportedService) MarshalJSON() ([]byte, error) {
 		Hash string `json:"hash"`
 		ExportedServiceMarshal
 	}{
-		Hash: hash,
+		Hash:                   hash,
 		ExportedServiceMarshal: ExportedServiceMarshal(*es),
 	}
 	return json.Marshal(&data)

--- a/pkg/controller/exportable_service_test.go
+++ b/pkg/controller/exportable_service_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -23,9 +23,11 @@ func ServiceFixture() *v1.Service {
 			Ports: []v1.ServicePort{
 				v1.ServicePort{
 					Name:     "http",
+					Port:     80,
 					NodePort: 32123},
 				v1.ServicePort{
 					Name:     "thing",
+					Port:     1234,
 					NodePort: 32124},
 			},
 		},
@@ -167,7 +169,7 @@ func TestId(t *testing.T) {
 		svc := ServiceFixture()
 		svc.Spec.Ports[0].Name = ""
 		es, _ := NewExportedService(svc, "cluster", 0)
-		assert.Equal(t, "cluster-default-service1-32123", es.Id())
+		assert.Equal(t, "cluster-default-service1-80", es.Id())
 	})
 }
 


### PR DESCRIPTION
In cases where the container port is unnamed, KSE currently uses the NodePort as a placeholder in the canonical service ID. However NodePort is likely to be unique per cluster, so this breaks any assumptions around multi-cluster load balancing.

This PR instead uses the port number (which is a better analog for the port name) for the canonical service Id, which will fix multi-cluster load balancing in cases where the port name is unspecified.