### PR TITLE
initial actions integration to push to gpr

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -1,0 +1,12 @@
+name: Docker Image CI
+on:
+  push:
+    branches: [ '*' ]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: git checkout
+      uses: actions/checkout@v1
+    - name: Build
+      run: docker build . --file Dockerfile

--- a/.github/workflows/dockertag.yml
+++ b/.github/workflows/dockertag.yml
@@ -1,0 +1,36 @@
+name: Push Tagged Image
+on:
+  push:
+    tags: [ 'v*' ]
+    branches: [ 'master']
+jobs:
+  build:
+    env:
+      TAG: ""
+    runs-on: ubuntu-latest
+    steps:
+    - name: git checkout
+      uses: actions/checkout@v1
+    - name: generate tag
+      run: |
+        TAG=${GITHUB_REF##*/}
+        if [ "$TAG" = "master" ]; then
+          TAG=latest
+        fi
+        echo "::set-env name=TAG::$TAG"
+
+    - name: log
+      run: echo Building image for ${TAG}
+    - name: Build the Docker image
+      run: |
+        docker build . --file Dockerfile \
+          --tag docker.pkg.github.com/github/kube-service-exporter/kube-service-exporter:${TAG} \
+          --tag github/kube-service-exporter:${TAG}
+    - name: docker login (GitHub)
+      run: docker login docker.pkg.github.com -u "$GITHUB_ACTOR" -p ${{ secrets.GITHUB_TOKEN }}
+    - name: docker push (GitHub)
+      run: docker push docker.pkg.github.com/github/kube-service-exporter/kube-service-exporter:${TAG}
+    - name: docker login (Docker Hub)
+      run: docker login -u "${{ secrets.DOCKER_LOGIN }}" -p "${{ secrets.DOCKER_TOKEN }}"
+    - name: docker push (Docker Hub)
+      run: docker push github/kube-service-exporter:${TAG}


### PR DESCRIPTION
This is a github action to push to github package registry and docker hub.  GPR doesn't support unauthenticated requests, so docker hub will be the canonical location.

These actions:
- build on all pushes
- pushes to docker hub on master pushes and new tags that start w/ `v`
- master pushes get tagged `latest` (haven't tested this yet because...I haven't merged to master yet)

cc: https://github.com/github/open-source-releases/issues/48