### PR TITLE
export service_per_cluster, omit empty values

### DIFF
--- a/pkg/controller/exportable_service.go
+++ b/pkg/controller/exportable_service.go
@@ -60,27 +60,27 @@ type ExportedService struct {
 	// The Port on which the Service is reachable
 	Port int32 `json:"port"`
 
-	DNSName           string `json:"dns_name"`
-	ServicePerCluster bool   `json:"-"`
+	DNSName           string `json:"dns_name,omitempty"`
+	ServicePerCluster bool   `json:"service_per_cluster,omitempty"`
 
 	// an optional URI Path for the HealthCheck
-	HealthCheckPath string `json:"health_check_path"`
+	HealthCheckPath string `json:"health_check_path,omitempty"`
 
 	// HealthCheckPort is a port for the Health Check. Defaults to the NodePort
-	HealthCheckPort int32 `json:"health_check_port"`
+	HealthCheckPort int32 `json:"health_check_port,omitempty"`
 
 	// TCP / HTTP
-	BackendProtocol string `json:"backend_protocol"`
+	BackendProtocol string `json:"backend_protocol,omitempty"`
 
 	// Enable Proxy protocol on the backend
-	ProxyProtocol bool `json:"proxy_protocol"`
+	ProxyProtocol bool `json:"proxy_protocol,omitempty"`
 
 	// LoadBalancerClass can be used to target the service at a specific load
 	// balancer (e.g. "internal", "public"
-	LoadBalancerClass string `json:"load_balancer_class"`
+	LoadBalancerClass string `json:"load_balancer_class,omitempty"`
 
 	// the port the load balancer should listen on
-	LoadBalancerListenPort int32 `json:"load_balancer_listen_port"`
+	LoadBalancerListenPort int32 `json:"load_balancer_listen_port,omitempty"`
 
 	CustomAttrs map[string]interface{} `json:"custom_attrs"`
 }

--- a/pkg/controller/exportable_service.go
+++ b/pkg/controller/exportable_service.go
@@ -83,6 +83,12 @@ type ExportedService struct {
 	LoadBalancerListenPort int32 `json:"load_balancer_listen_port,omitempty"`
 
 	CustomAttrs map[string]interface{} `json:"custom_attrs"`
+
+	// Version is a version specifier that can be used to force the Hash function
+	// to change and thus rewrite the service metadata. This is useful in cases
+	// where the JSON serialization of the object changes, but not the struct
+	// itself.
+	Version int `json:"-"`
 }
 
 // NewExportedServicesFromKubeService returns a slice of ExportedServices, one
@@ -131,6 +137,7 @@ func NewExportedService(service *v1.Service, clusterId string, portIdx int) (*Ex
 		ServicePerCluster: true,
 		BackendProtocol:   "http",
 		ClusterId:         clusterId,
+		Version:           1,
 	}
 
 	if es.PortName == "" {

--- a/pkg/controller/exportable_service_test.go
+++ b/pkg/controller/exportable_service_test.go
@@ -198,7 +198,7 @@ func TestJSON(t *testing.T) {
 	assert.NoError(t, err)
 	expected := `{ "service_per_cluster": true,
 					"health_check_port": 32123,
-					"hash": "da96e1c925945147",
+					"hash": "b2e9f54c0b6f432b",
 					"ClusterName": "cluster",
 					"port": 32123,
 					"custom_attrs": {},

--- a/pkg/controller/exportable_service_test.go
+++ b/pkg/controller/exportable_service_test.go
@@ -196,17 +196,13 @@ func TestJSON(t *testing.T) {
 	es, _ := NewExportedService(ServiceFixture(), "cluster", 0)
 	b, err := json.Marshal(es)
 	assert.NoError(t, err)
-	expected := `{ "health_check_path": "",
+	expected := `{ "service_per_cluster": true,
 					"health_check_port": 32123,
-					"proxy_protocol": false,
-					"load_balancer_listen_port": 0,
 					"hash": "da96e1c925945147",
 					"ClusterName": "cluster",
 					"port": 32123,
-					"dns_name": "",
-					"backend_protocol": "http",
 					"custom_attrs": {},
-					"load_balancer_class": "" }`
+					"backend_protocol": "http" }`
 
 	assert.JSONEq(t, expected, string(b))
 }


### PR DESCRIPTION
This exports the `service_per_cluster` value if it is set to `true` for use within templates as well as only exporting json values that are set, which should help with consul-template key sizes in dedup mode.