### PR TITLE
allow NodePort Services to be exported

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Kubernetes controller for enabling load balancing *across multiple clusters*, 
 
 By exporting Kubernetes Service and Node metadata to Consul, `kube-service-exporter` facilitates bringing an external load balancer to Kubernetes installations for highly available cluster designs.
 
-## Overview 
+## Overview
 
 Traffic ingress into a Kubernetes cluster from on-prem or custom load balancers is complex. Commonly, Ingress controllers are used to support this use case, but  this creates an often unnecessary intermediate proxy and TCP/L4 ingress is still poorly supported. `kube-service-exporter` runs inside the cluster and exports metadata about Kubernetes Services and Nodes to Consul which can be used to configure a custom load balancer according to individual needs.  Services exported by `kube-service-exporter` can be configured to load balance parallel deployments of the same service across multiple Kubernetes clusters, allowing Kubernetes clusters to be highly available. Metadata about the configuration is stored in Annotations on the Service resource which mirror the Service Annotations used when configuring cloud load balancers for providers such as AWS and GCE.
 
@@ -20,7 +20,7 @@ Traffic ingress into a Kubernetes cluster from on-prem or custom load balancers 
 
 ### Services (Consul KV)
 
-Metadata is exported to Consul for Kubernetes Services of `type: LoadBalancer` with the `kube-service-exporter.github.com/exported` annotation set to `"true"`.  The exported metadata for each Kubernetes Service is available at `$KSE_KV_PREFIX/services/$SERVICE_NAME/clusters/$CLUSTER_ID`.  This path warrants some explanation:
+Metadata is exported to Consul for Kubernetes Services of `type: LoadBalancer` or `type: NodePort` with the `kube-service-exporter.github.com/exported` annotation set to `"true"`.  The exported metadata for each Kubernetes Service is available at `$KSE_KV_PREFIX/services/$SERVICE_NAME/clusters/$CLUSTER_ID`.  This path warrants some explanation:
 
 * `KSE_KV_PREFIX` is the value of the `KSE_KV_PREFIX` environment variable passed in and defaults to `kube-service-exporter`.
 * `SERVICE_NAME` is a generated string that uniquely identifies an exported service as `(${CLUSTER_ID}-)${NAMESPACE}-${SERVICE_NAME}-${SERVICE_PORT}`
@@ -131,7 +131,7 @@ When configured to export Consul Services, the Kubernetes Service above would ha
 
 ### Nodes (Consul KV)
 
-Metadata about Kubernetes Nodes in the Kubernetes cluster is stored as a JSON array in Consul KV under `$KSE_KV_PREFIX/nodes/$KSE_CLUSTER_ID`. 
+Metadata about Kubernetes Nodes in the Kubernetes cluster is stored as a JSON array in Consul KV under `$KSE_KV_PREFIX/nodes/$KSE_CLUSTER_ID`.
 
 ```javascript
 $ consul kv get kube-service-exporter/nodes/mycluster
@@ -194,7 +194,7 @@ Exported services are configured with Annotations on the Service, but `kube-serv
 
 Please see an [example deploy here](/examples/deploy-example.md).
 
-### Operation 
+### Operation
 
 ## How To Use
 
@@ -219,4 +219,4 @@ kube-service-exporter is licensed under the [Apache 2.0 license](LICENSE).
 
 `kube-service-exporter` was originally designed and authored by [Aaron Brown](https://github.com/aaronbbrown).
 It is maintained, reviewed, and tested by the Production Engineering team at GitHub.
-Contact the maintainers: opensource+kube-service-exporter@github.com 
+Contact the maintainers: opensource+kube-service-exporter@github.com

--- a/pkg/controller/exportable_service.go
+++ b/pkg/controller/exportable_service.go
@@ -217,6 +217,11 @@ func (es *ExportedService) Hash() (string, error) {
 	return strconv.FormatUint(hash, 16), nil
 }
 
+// IsExportableService returns true if:
+// - the target Service has the kube-service-exporter.github.com/exported
+//   annotation set to a value which evalutes to a boolean (e.g. "true", "1")
+// AND
+// - is a type: LoadBalancer or type: NodePort Service.
 func IsExportableService(service *v1.Service) bool {
 	var exported bool
 
@@ -227,7 +232,13 @@ func IsExportableService(service *v1.Service) bool {
 		}
 		exported = parsed
 	}
-	return exported && service.Spec.Type == v1.ServiceTypeLoadBalancer
+
+	if !exported {
+		return false
+	}
+
+	return service.Spec.Type == v1.ServiceTypeLoadBalancer ||
+		service.Spec.Type == v1.ServiceTypeNodePort
 }
 
 func (es *ExportedService) MarshalJSON() ([]byte, error) {

--- a/pkg/controller/exportable_service_test.go
+++ b/pkg/controller/exportable_service_test.go
@@ -40,10 +40,16 @@ func TestIsExportableService(t *testing.T) {
 		assert.True(t, IsExportableService(svc))
 	})
 
-	t.Run("NodePort Service is not exportable", func(t *testing.T) {
+	t.Run("ClusterIP Service is not exportable", func(t *testing.T) {
 		svc := ServiceFixture()
-		svc.Spec.Type = "NodePort"
+		svc.Spec.Type = v1.ServiceTypeClusterIP
 		assert.False(t, IsExportableService(svc))
+	})
+
+	t.Run("NodePort Service is exportable", func(t *testing.T) {
+		svc := ServiceFixture()
+		svc.Spec.Type = v1.ServiceTypeNodePort
+		assert.True(t, IsExportableService(svc))
 	})
 
 	t.Run("Service w/out exported annotation is not exportable", func(t *testing.T) {
@@ -139,7 +145,7 @@ func TestNewExportedServicesFromKubeServices(t *testing.T) {
 
 	t.Run("Invalid Service Type", func(t *testing.T) {
 		svc := ServiceFixture()
-		svc.Spec.Type = "NodePort"
+		svc.Spec.Type = v1.ServiceTypeClusterIP
 		_, err := NewExportedServicesFromKubeService(svc, "cluster")
 		assert.Error(t, err)
 	})

--- a/pkg/controller/service_watcher.go
+++ b/pkg/controller/service_watcher.go
@@ -168,7 +168,8 @@ func (sw *ServiceWatcher) updateService(oldService *v1.Service, newService *v1.S
 	stats.Client().Incr("kubernetes.service_handler", tags, 1)
 	defer stats.Client().Timing("kubernetes.service_handler.time", time.Since(start), tags, 1)
 
-	// Delete services that are not exportable (because they aren't LoadBalancer/opt-in)
+	// Delete services that are not exportable (because they aren't
+	// LoadBalancer, NodePort, or opt-in)
 	if !IsExportableService(newService) {
 		// delete the
 		sw.deleteService(oldService, target)

--- a/pkg/controller/service_watcher_test.go
+++ b/pkg/controller/service_watcher_test.go
@@ -219,7 +219,7 @@ func (s *ServiceWatcherSuite) TestUpdateTriggersDelete() {
 	svc := *s.serviceFixture
 	s.SourceExec(s.source.Add, &svc, []string{"create"})
 	s.Len(s.target.Store, 2)
-	svc.Spec.Type = "NodePort"
+	svc.Spec.Type = v1.ServiceTypeClusterIP
 	s.SourceExec(s.source.Modify, &svc, []string{"delete"})
 	s.Len(s.target.Store, 0)
 }


### PR DESCRIPTION
This allows `type: NodePort` Services to be exported. Previously only `type: LoadBalancer` Services were allowed to be exported due to my misunderstanding of the intent behind them. Normally, in a cloud environment the `Service.Status.LoadBalancer[].Hostnanme` property would be populated by the controller creating the Load Balancer. While we probably _should_ eventually do via some mechanism, the primary use case for `kube-service-exporter` at GitHub does not require that and a simple `NodePort` will suffice. This has most recently come up when trying to deploy https://voyagermesh.com (which will **not** create a `type: LoadBalancer` for metal deployments).

This should be a backwards compatible change since the `exported` annotation needs to be set for the service to be exported into consul.

xref: https://github.com/github/fast/issues/160#issuecomment-804208923
