### PR TITLE
Reaplace set-env with environment-files

### DIFF
--- a/.github/workflows/dockertag.yml
+++ b/.github/workflows/dockertag.yml
@@ -1,8 +1,9 @@
 name: Push Tagged Image
 on:
   push:
-    tags: [ 'v*' ]
-    branches: [ 'master']
+    # tags: [ 'v*' ]
+    # branches: [ 'master']
+    branches: [ '*']
 jobs:
   build:
     env:

--- a/.github/workflows/dockertag.yml
+++ b/.github/workflows/dockertag.yml
@@ -17,20 +17,20 @@ jobs:
         if [ "$TAG" = "master" ]; then
           TAG=latest
         fi
-        echo "::set-env name=TAG::$TAG"
+        echo "TAG=$TAG" >> $GITHUB_ENV
 
     - name: log
-      run: echo Building image for ${TAG}
+      run: echo Building image for ${{ env.TAG }}
     - name: Build the Docker image
       run: |
         docker build . --file Dockerfile \
-          --tag docker.pkg.github.com/github/kube-service-exporter/kube-service-exporter:${TAG} \
-          --tag github/kube-service-exporter:${TAG}
+          --tag docker.pkg.github.com/github/kube-service-exporter/kube-service-exporter:${{ env.TAG }} \
+          --tag github/kube-service-exporter:${{ env.TAG }}
     - name: docker login (GitHub)
       run: docker login docker.pkg.github.com -u "$GITHUB_ACTOR" -p ${{ secrets.GITHUB_TOKEN }}
     - name: docker push (GitHub)
-      run: docker push docker.pkg.github.com/github/kube-service-exporter/kube-service-exporter:${TAG}
+      run: docker push docker.pkg.github.com/github/kube-service-exporter/kube-service-exporter:${{ env.TAG }}
     - name: docker login (Docker Hub)
       run: docker login -u "${{ secrets.DOCKER_LOGIN }}" -p "${{ secrets.DOCKER_TOKEN }}"
     - name: docker push (Docker Hub)
-      run: docker push github/kube-service-exporter:${TAG}
+      run: docker push github/kube-service-exporter:${{ env.TAG }}

--- a/.github/workflows/dockertag.yml
+++ b/.github/workflows/dockertag.yml
@@ -1,9 +1,8 @@
 name: Push Tagged Image
 on:
   push:
-    # tags: [ 'v*' ]
-    # branches: [ 'master']
-    branches: [ '*']
+    tags: [ 'v*' ]
+    branches: [ 'master']
 jobs:
   build:
     env:


### PR DESCRIPTION
`set-env` has been deprecated:
> Error: Unable to process command '::set-env name=TAG::latest' successfully.
Error: The `set-env` command is disabled. Please upgrade to using Environment Files or opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

Replace its use with [environment files](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#environment-files).

cc @github/compute-foundation 