### PR TITLE
Fix codeql cron job

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -18,7 +18,7 @@ name: "CodeQL"
     # The branches below must be a subset of the branches above
     branches: [ master ]
   schedule:
-    - cron: '12 1 * * 5'
+    - cron: 12 1 * * 5
 
 jobs:
   analyze:


### PR DESCRIPTION
Revising the routine cron job to alleviate this [intermittent codeQL violation](https://catalog.githubapp.com/services/kube-service-exporter/scorecards/code-scanning-fundamental).

Feel free to adjust if another interval is desired. This needs to run at least weekly to satisfy the code scanning fundamental.